### PR TITLE
for ansible1.9 ( or higher ) sudo -> become

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Malk’Zameth
   description: Java8 from Oracle, using the webupd8 ppa
   license: GPLv3
-  min_ansible_version: 1.6
+  min_ansible_version: 1.9
   platforms:
     - name: Ubuntu
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,18 @@
 ---
 - name: Install add-apt-repostory
-  sudo: yes
+  become: yes
   apt: name=software-properties-common state=latest
 
 - name: Add Oracle Java Repository
-  sudo: yes
+  become: yes
   apt_repository: repo='ppa:webupd8team/java'
 
 - name: Accept Java 8 License
-  sudo: yes
+  become: yes
   debconf: name='oracle-java8-installer' question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'
 
 - name: Install Oracle Java 8
-  sudo: yes
+  become: yes
   apt: name={{item}} state=latest
   with_items:
     - oracle-java8-installer


### PR DESCRIPTION
sudo is deprecated in Ansible 1.9 or higher.
http://docs.ansible.com/ansible/become.html

So, I modified some small changes.
Please, check this.
